### PR TITLE
add functions and tests for OPTIONS and HEAD methods of http

### DIFF
--- a/goweb/0_HELPER_test.go
+++ b/goweb/0_HELPER_test.go
@@ -60,6 +60,8 @@ func (cr *TestRestController) UpdateMany(cx *Context) {
 	cr.lastCall = "UpdateMany"
 	cr.lastId = "(none)"
 }
+func (cr *TestRestController) Options(cx *Context) { cr.lastCall = "Options"; cr.lastId = "(none)" }
+func (cr *TestRestController) Head(cx *Context)    { cr.lastCall = "Head"; cr.lastId = "(none)" }
 
 /*
 	Test ResponseWriter

--- a/goweb/constants.go
+++ b/goweb/constants.go
@@ -12,6 +12,8 @@ const GET_HTTP_METHOD string = "GET"
 const POST_HTTP_METHOD string = "POST"
 const PUT_HTTP_METHOD string = "PUT"
 const DELETE_HTTP_METHOD string = "DELETE"
+const OPTIONS_HTTP_METHOD string = "OPTIONS"
+const HEAD_HTTP_METHOD string = "HEAD"
 
 /*
 	Error messages

--- a/goweb/context.go
+++ b/goweb/context.go
@@ -76,6 +76,16 @@ func (c *Context) IsDelete() bool {
 	return c.Request.Method == DELETE_HTTP_METHOD
 }
 
+// Checks whether the HTTP method is OPTIONS or not
+func (c *Context) IsOptions() bool {
+	return c.Request.Method == OPTIONS_HTTP_METHOD
+}
+
+// Checks whether the HTTP method is HEAD or not
+func (c *Context) IsHead() bool {
+	return c.Request.Method == HEAD_HTTP_METHOD
+}
+
 /*
 	RespondWith* methods
 */

--- a/goweb/context_test.go
+++ b/goweb/context_test.go
@@ -138,6 +138,16 @@ func AssertNotDelete(c *Context, t *testing.T) {
 		t.Errorf("IsDelete should be false for '%s' method.", c.Request.Method)
 	}
 }
+func AssertNotOptions(c *Context, t *testing.T) {
+	if c.IsOptions() {
+		t.Errorf("IsOptions should be false for '%s' method.", c.Request.Method)
+	}
+}
+func AssertNotHead(c *Context, t *testing.T) {
+	if c.IsHead() {
+		t.Errorf("IsHead should be false for '%s' method.", c.Request.Method)
+	}
+}
 func AssertGet(c *Context, t *testing.T) {
 	if !c.IsGet() {
 		t.Errorf("IsGet should be true for '%s' method.", c.Request.Method)
@@ -156,6 +166,16 @@ func AssertPut(c *Context, t *testing.T) {
 func AssertDelete(c *Context, t *testing.T) {
 	if !c.IsDelete() {
 		t.Errorf("IsDelete should be true for '%s' method.", c.Request.Method)
+	}
+}
+func AssertOptions(c *Context, t *testing.T) {
+	if !c.IsOptions() {
+		t.Errorf("IsOptions should be true for '%s' method.", c.Request.Method)
+	}
+}
+func AssertHead(c *Context, t *testing.T) {
+	if !c.IsHead() {
+		t.Errorf("IsHead should be true for '%s' method.", c.Request.Method)
 	}
 }
 
@@ -183,6 +203,8 @@ func TestIsPost(t *testing.T) {
 	AssertPost(context, t)
 	AssertNotPut(context, t)
 	AssertNotDelete(context, t)
+	AssertNotOptions(context, t)
+	AssertNotHead(context, t)
 
 }
 func TestIsPut(t *testing.T) {
@@ -196,6 +218,8 @@ func TestIsPut(t *testing.T) {
 	AssertNotPost(context, t)
 	AssertPut(context, t)
 	AssertNotDelete(context, t)
+	AssertNotOptions(context, t)
+	AssertNotHead(context, t)
 
 }
 func TestIsDelete(t *testing.T) {
@@ -209,6 +233,38 @@ func TestIsDelete(t *testing.T) {
 	AssertNotPost(context, t)
 	AssertNotPut(context, t)
 	AssertDelete(context, t)
+	AssertNotOptions(context, t)
+	AssertNotHead(context, t)
+
+}
+func TestIsOptions(t *testing.T) {
+
+	context := MakeTestContext()
+
+	// set the request method
+	context.Request.Method = OPTIONS_HTTP_METHOD
+
+	AssertNotGet(context, t)
+	AssertNotPost(context, t)
+	AssertNotPut(context, t)
+	AssertNotDelete(context, t)
+	AssertOptions(context, t)
+	AssertNotHead(context, t)
+
+}
+func TestIsHead(t *testing.T) {
+
+	context := MakeTestContext()
+
+	// set the request method
+	context.Request.Method = HEAD_HTTP_METHOD
+
+	AssertNotGet(context, t)
+	AssertNotPost(context, t)
+	AssertNotPut(context, t)
+	AssertNotDelete(context, t)
+	AssertNotOptions(context, t)
+	AssertHead(context, t)
 
 }
 

--- a/goweb/rest_controller.go
+++ b/goweb/rest_controller.go
@@ -35,5 +35,15 @@ type RestManyDeleter interface {
 	DeleteMany(c *Context)
 }
 
+// Handler method for OPTIONS method
+type RestOptions interface {
+	Options(c *Context)
+}
+
+// Handler method to get header
+type RestHead interface {
+	Head(c *Context)
+}
+
 // Interface for RESTful controllers
 type RestController interface{}

--- a/goweb/route_matching.go
+++ b/goweb/route_matching.go
@@ -51,3 +51,23 @@ func PostMethod(c *Context) RouteMatcherFuncValue {
 	}
 	return DontCare
 }
+
+// Returns Match if the Method of the http.Request in the specified
+// Context is OPTIONS, otherwise returns DontCare
+func OptionsMethod(c *Context) RouteMatcherFuncValue {
+	if c.IsOptions() {
+		return Match
+	}
+
+	return DontCare
+}
+
+// Returns Match if the Method of the http.Request in the specified
+// Context is HEAD, otherwise returns DontCare
+func HeadMethod(c *Context) RouteMatcherFuncValue {
+	if c.IsHead() {
+		return Match
+	}
+
+	return DontCare
+}

--- a/goweb/route_matching_test.go
+++ b/goweb/route_matching_test.go
@@ -38,6 +38,12 @@ func TestRouteMatcher_xMethods(t *testing.T) {
 	if PostMethod(context) != DontCare {
 		t.Errorf("PostMethod on a GET context should DontCare")
 	}
+	if OptionsMethod(context) != DontCare {
+		t.Errorf("OptionsMethod on a GET context should DontCare")
+	}
+	if HeadMethod(context) != DontCare {
+		t.Errorf("HeadMethod on a GET context should DontCare")
+	}
 
 	request.Method = POST_HTTP_METHOD
 
@@ -52,6 +58,12 @@ func TestRouteMatcher_xMethods(t *testing.T) {
 	}
 	if PostMethod(context) != Match {
 		t.Errorf("PostMethod on a POST context should Match")
+	}
+	if OptionsMethod(context) != DontCare {
+		t.Errorf("OptionsMethod on a POST context should DontCare")
+	}
+	if HeadMethod(context) != DontCare {
+		t.Errorf("HeadMethod on a POST context should DontCare")
 	}
 
 	request.Method = PUT_HTTP_METHOD
@@ -68,6 +80,12 @@ func TestRouteMatcher_xMethods(t *testing.T) {
 	if PostMethod(context) != DontCare {
 		t.Errorf("PostMethod on a PUT context should DontCare")
 	}
+	if OptionsMethod(context) != DontCare {
+		t.Errorf("OptionsMethod on a PUT context should DontCare")
+	}
+	if HeadMethod(context) != DontCare {
+		t.Errorf("HeadMethod on a PUT context should DontCare")
+	}
 
 	request.Method = DELETE_HTTP_METHOD
 
@@ -75,7 +93,7 @@ func TestRouteMatcher_xMethods(t *testing.T) {
 		t.Errorf("GetMethod on a DELETE context should DontCare")
 	}
 	if PutMethod(context) != DontCare {
-		t.Errorf("PutMethod on a DELETE context should Match")
+		t.Errorf("PutMethod on a DELETE context should DontCare")
 	}
 	if DeleteMethod(context) != Match {
 		t.Errorf("DeleteMethod on a DELETE context should Match")
@@ -83,5 +101,52 @@ func TestRouteMatcher_xMethods(t *testing.T) {
 	if PostMethod(context) != DontCare {
 		t.Errorf("PostMethod on a DELETE context should DontCare")
 	}
+	if OptionsMethod(context) != DontCare {
+		t.Errorf("OptionsMethod on a DELETE context should DontCare")
+	}
+	if HeadMethod(context) != DontCare {
+		t.Errorf("HeadMethod on a DELETE context should DontCare")
+	}
 
+	request.Method = OPTIONS_HTTP_METHOD
+
+	if GetMethod(context) != DontCare {
+		t.Errorf("GetMethod on a OPTIONS context should DontCare")
+	}
+	if PutMethod(context) != DontCare {
+		t.Errorf("PutMethod on a OPTIONS context should DontCare")
+	}
+	if DeleteMethod(context) != DontCare {
+		t.Errorf("DeleteMethod on a OPTIONS context should DontCare")
+	}
+	if PostMethod(context) != DontCare {
+		t.Errorf("PostMethod on a OPTIONS context should DontCare")
+	}
+	if OptionsMethod(context) != Match {
+		t.Errorf("OptionsMethod on a OPTIONS context should Match")
+	}
+	if HeadMethod(context) != DontCare {
+		t.Errorf("HeadMethod on a OPTIONS context should DontCare")
+	}
+
+	request.Method = HEAD_HTTP_METHOD
+
+	if GetMethod(context) != DontCare {
+		t.Errorf("GetMethod on a HEAD context should DontCare")
+	}
+	if PutMethod(context) != DontCare {
+		t.Errorf("PutMethod on a HEAD context should DontCare")
+	}
+	if DeleteMethod(context) != DontCare {
+		t.Errorf("DeleteMethod on a HEAD context should DontCare")
+	}
+	if PostMethod(context) != DontCare {
+		t.Errorf("PostMethod on a HEAD context should DontCare")
+	}
+	if OptionsMethod(context) != DontCare {
+		t.Errorf("OptionsMethod on a HEAD context should DontCare")
+	}
+	if HeadMethod(context) != Match {
+		t.Errorf("HeadMethod on a HEAD context should Match")
+	}
 }

--- a/goweb/shortcut_funcs.go
+++ b/goweb/shortcut_funcs.go
@@ -83,6 +83,19 @@ func MapRest(pathPrefix string, controller RestController) {
 			rc.Create(c)
 		}, PostMethod)
 	}
+	// OPTION /resource
+	if rc, ok := controller.(RestOptions); ok {
+		MapFunc(pathPrefix, func(c *Context) {
+			rc.Options(c)
+		}, OptionsMethod)
+	}
+	// HEAD /resource
+	if rc, ok := controller.(RestHead); ok {
+		MapFunc(pathPrefix, func(c *Context) {
+			rc.Head(c)
+		}, HeadMethod)
+	}
+
 }
 
 // Maps a path to a static directory

--- a/goweb/shortcut_funcs_test.go
+++ b/goweb/shortcut_funcs_test.go
@@ -60,7 +60,7 @@ func TestMapRest(t *testing.T) {
 
 	MapRest("/people", testRestController)
 
-	if len(DefaultRouteManager.routes) != 7 {
+	if len(DefaultRouteManager.routes) != 9 {
 		t.Errorf("There shouldn't be %d route(s)", len(DefaultRouteManager.routes))
 	} else {
 
@@ -113,6 +113,20 @@ func TestMapRest(t *testing.T) {
 		assertRoute(t, route, "/people", "POST", PostMethod)
 		handleRequest("/people", "POST")
 		assertLastCall(t, testRestController.(*TestRestController), "Create")
+		assertNoLastId(t, testRestController.(*TestRestController))
+
+		// OPTIONS /people
+		route = DefaultRouteManager.routes[7]
+		assertRoute(t, route, "/people", "OPTIONS", OptionsMethod)
+		handleRequest("/people", "OPTIONS")
+		assertLastCall(t, testRestController.(*TestRestController), "Options")
+		assertNoLastId(t, testRestController.(*TestRestController))
+
+		// HEAD /people
+		route = DefaultRouteManager.routes[8]
+		assertRoute(t, route, "/people", "HEAD", HeadMethod)
+		handleRequest("/people", "HEAD")
+		assertLastCall(t, testRestController.(*TestRestController), "Head")
 		assertNoLastId(t, testRestController.(*TestRestController))
 
 	}


### PR DESCRIPTION
I added functions and tests for OPTIONS and HEAD methods of http.
Because some web browsers use OPTIONS method to checkAccess-Control-Allow-Origin and related headers (see: https://developer.mozilla.org/en-US/docs/HTTP/Access_control_CORS).
For example, users want to separate a RESTful API server from a webserver which provides only static files (html, css, and js), users should be set Access-Control-Allow-Origin header to api response when access by OPTIONS method because the origin of the webserver is different from RESTful API's one.
