### PR TITLE
security bug: static file serving arbitrary file/source

### DIFF
--- a/handlers/mapping_test.go
+++ b/handlers/mapping_test.go
@@ -430,6 +430,18 @@ func TestMapStatic(t *testing.T) {
 	willHandle, _ = staticHandler.WillHandle(ctx)
 	assert.True(t, willHandle, "Static handler should handle")
 
+	ctx = context_test.MakeTestContextWithPath("/static/../static/some/deep/file.dat")
+	willHandle, _ = staticHandler.WillHandle(ctx)
+	assert.True(t, willHandle, "Static handler should handle")
+
+	ctx = context_test.MakeTestContextWithPath("/static/some/../file.dat")
+	willHandle, _ = staticHandler.WillHandle(ctx)
+	assert.True(t, willHandle, "Static handler should handle")
+
+	ctx = context_test.MakeTestContextWithPath("/static/../file.dat")
+	willHandle, _ = staticHandler.WillHandle(ctx)
+	assert.False(t, willHandle, "Static handler should not handle")
+
 	ctx = context_test.MakeTestContextWithPath("/static")
 	willHandle, _ = staticHandler.WillHandle(ctx)
 	assert.True(t, willHandle, "Static handler should handle")

--- a/paths/path.go
+++ b/paths/path.go
@@ -3,7 +3,7 @@ package paths
 import (
 	"fmt"
 	"strings"
-	pth "path"
+	"path"
 )
 
 // Path represents the path segment of a URL.
@@ -29,8 +29,8 @@ func NewPath(rawPath string) *Path {
 }
 
 // cleanPath cleans returns the cleaned version of the specified path.
-func cleanPath(path string) string {
-	return strings.TrimRight(strings.TrimLeft(pth.Join(path), PathSeperator), PathSeperator)
+func cleanPath(rawPath string) string {
+	return strings.TrimRight(strings.TrimLeft(path.Clean(rawPath), PathSeperator), PathSeperator)
 }
 
 // PathFromSegments turns the arguments into a path string.

--- a/paths/path.go
+++ b/paths/path.go
@@ -3,6 +3,7 @@ package paths
 import (
 	"fmt"
 	"strings"
+	pth "path"
 )
 
 // Path represents the path segment of a URL.
@@ -29,7 +30,7 @@ func NewPath(rawPath string) *Path {
 
 // cleanPath cleans returns the cleaned version of the specified path.
 func cleanPath(path string) string {
-	return strings.TrimRight(strings.TrimLeft(path, PathSeperator), PathSeperator)
+	return strings.TrimRight(strings.TrimLeft(pth.Join(path), PathSeperator), PathSeperator)
 }
 
 // PathFromSegments turns the arguments into a path string.


### PR DESCRIPTION
Hi,
when a server comes up with a static serving directory. from client side it is able to access arbitrary file using relative path.

for example: my server is serving `/static` for static files, i can get `/etc/passwd` by requesting `/static/../../../../../../etc/passwd`

```
$ telnet localhost 9123
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
GET /static/../../../../../../etc/passwd HTTP/1.0

HTTP/1.0 200 OK
Accept-Ranges: bytes
Content-Length: 1234
Content-Type: text/plain; charset=utf-8
Last-Modified: Sat, 01 Aug 2012 05:13:28 GMT
X-Custom-Header: Goweb
Connection: close
Date: Wed, 05 Jun 2013 04:30:46 GMT

root:x:0:0:root:/root:/bin/bash
........
```
