### PR TITLE
Test Helper Can't Build on GAE

### DIFF
--- a/test_helper.go
+++ b/test_helper.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 package goweb
 
 import (


### PR DESCRIPTION
GAE doesn't allow the use of the unsafe package.  The reflect.ValueOf method uses the unsafe package.  testify/assert/assertions.go on line 27 uses reflect.ValueOf.  End result: the tests can't be built on GAE.  But that shouldn't really be a problem, since they're run locally before they're ever uploaded to GAE servers.

Anyway, adding a build constraint to test_helper.go fixes the problem, allowing goweb to be built on GAE servers.  I'm sure that there are other parts of goweb that can't be used (I noticed that the codecs service being used uses reflect.ValueOf in some places); but as long as goweb can actually be built on GAE, those other issues can easily be worked around.
