### PR TITLE
Remove the query string from the path's extension if one exists. Fixes #75

### DIFF
--- a/webcontext/web_context.go
+++ b/webcontext/web_context.go
@@ -65,7 +65,11 @@ func (c *WebContext) Data() objx.Map {
 
 // FileExtension gets the extension of the file from the HttpRequest().
 func (c *WebContext) FileExtension() string {
-	return strings.ToLower(path.Ext(c.HttpRequest().URL.RequestURI()))
+	ext := strings.ToLower(path.Ext(c.HttpRequest().URL.RequestURI()))
+	if idx := strings.Index("?", ext); idx != -1 {
+		ext = ext[:idx]
+	}
+	return ext
 }
 
 // RequestData gets the data out of the body of the request as a usable object.

--- a/webcontext/web_context_test.go
+++ b/webcontext/web_context_test.go
@@ -76,8 +76,8 @@ func TestFileExtension(t *testing.T) {
 	assert.Equal(t, ".xml", c.FileExtension())
 
 	testRequest, _ = http.NewRequest("get", "http://goweb.org/people.with.dots/123.xml?a=b", nil)
-        c = NewWebContext(responseWriter, testRequest, codecService)
-        assert.Equal(t, ".xml", c.FileExtension())
+	c = NewWebContext(responseWriter, testRequest, codecService)
+	assert.Equal(t, ".xml", c.FileExtension())
 
 }
 

--- a/webcontext/web_context_test.go
+++ b/webcontext/web_context_test.go
@@ -75,6 +75,10 @@ func TestFileExtension(t *testing.T) {
 	c = NewWebContext(responseWriter, testRequest, codecService)
 	assert.Equal(t, ".xml", c.FileExtension())
 
+	testRequest, _ = http.NewRequest("get", "http://goweb.org/people.with.dots/123.xml?a=b", nil)
+        c = NewWebContext(responseWriter, testRequest, codecService)
+        assert.Equal(t, ".xml", c.FileExtension())
+
 }
 
 func TestMethodString(t *testing.T) {


### PR DESCRIPTION
Removes the query string from the path's extension.
