### PR TITLE
Codec options passthrough

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -66,6 +66,9 @@ type Context interface {
 	// CodecOptions gets a map of options that are passed to codecs
 	// upon responding.  If you need to pass additional options to a
 	// codec, you can add data to the value returned by this method.
+	// Responders may add data to the value returned by this method
+	// before passing these options to the chosen codec, but they
+	// should never overwrite or remove options.
 	CodecOptions() objx.Map
 
 	// CodecService gets the codecsservices.CodecService that this Context will use to marshal

--- a/context/context.go
+++ b/context/context.go
@@ -64,7 +64,8 @@ type Context interface {
 	Data() objx.Map
 
 	// CodecOptions gets a map of options that are passed to codecs
-	// upon responding.
+	// upon responding.  If you need to pass additional options to a
+	// codec, you can add data to the value returned by this method.
 	CodecOptions() objx.Map
 
 	// CodecService gets the codecsservices.CodecService that this Context will use to marshal

--- a/context/context.go
+++ b/context/context.go
@@ -63,6 +63,10 @@ type Context interface {
 	// Data gets a map of data about the context.
 	Data() objx.Map
 
+	// CodecOptions gets a map of options that are passed to codecs
+	// upon responding.
+	CodecOptions() objx.Map
+
 	// CodecService gets the codecsservices.CodecService that this Context will use to marshal
 	// and unmarshal data to and from objects.
 	CodecService() codecsservices.CodecService

--- a/responders/api_responder.go
+++ b/responders/api_responder.go
@@ -15,6 +15,10 @@ var (
 
 /*
   APIResponder represents objects capable of provide API responses.
+  Note that when one of the response methods is called, it may
+  (depending on the request) add data to the map returned by
+  context.Context.CodecOptions() before passing it off to the chosen
+  codec's Marshal method.
 */
 type APIResponder interface {
 
@@ -51,7 +55,9 @@ type APIResponder interface {
 	Respond(ctx context.Context, status int, data interface{}, errors []string) error
 
 	// WriteResponseObject writes the status code and response object to the HttpResponseWriter in
-	// the specified context, in the format best suited based on the request.
+	// the specified context, in the format best suited based on the
+	// request.  In certain cases, some data may be added to the
+	// passed in context.Context value's CodecOptions() value.
 	//
 	// Goweb uses the WebCodecService to decide which codec to use when responding
 	// see http://godoc.org/github.com/stretchr/codecs/services#WebCodecService for more information.

--- a/responders/goweb_api_responder.go
+++ b/responders/goweb_api_responder.go
@@ -112,7 +112,7 @@ func (a *GowebAPIResponder) WriteResponseObject(ctx context.Context, status int,
 	options := ctx.CodecOptions()
 
 	// do we need to add some options?
-	if hasCallback {
+	if _, exists := options[constants.OptionKeyClientCallback]; hasCallback && !exists {
 		options[constants.OptionKeyClientCallback] = ctx.QueryValue(CallbackParameter)
 	}
 

--- a/responders/goweb_api_responder.go
+++ b/responders/goweb_api_responder.go
@@ -113,8 +113,6 @@ func (a *GowebAPIResponder) WriteResponseObject(ctx context.Context, status int,
 
 	// do we need to add some options?
 	if hasCallback {
-		// Don't modify the original
-		options = options.Copy()
 		options[constants.OptionKeyClientCallback] = ctx.QueryValue(CallbackParameter)
 	}
 

--- a/responders/goweb_api_responder.go
+++ b/responders/goweb_api_responder.go
@@ -109,11 +109,11 @@ func (a *GowebAPIResponder) WriteResponseObject(ctx context.Context, status int,
 		return codecError
 	}
 
-	var options map[string]interface{}
+	options := ctx.CodecOptions()
 
 	// do we need to add some options?
 	if hasCallback {
-		options = map[string]interface{}{constants.OptionKeyClientCallback: ctx.QueryValue(CallbackParameter)}
+		options[constants.OptionKeyClientCallback] = ctx.QueryValue(CallbackParameter)
 	}
 
 	output, marshalErr := service.MarshalWithCodec(codec, responseObject, options)

--- a/responders/goweb_api_responder.go
+++ b/responders/goweb_api_responder.go
@@ -113,6 +113,8 @@ func (a *GowebAPIResponder) WriteResponseObject(ctx context.Context, status int,
 
 	// do we need to add some options?
 	if hasCallback {
+		// Don't modify the original
+		options = options.Copy()
 		options[constants.OptionKeyClientCallback] = ctx.QueryValue(CallbackParameter)
 	}
 

--- a/responders/goweb_api_responder_test.go
+++ b/responders/goweb_api_responder_test.go
@@ -232,7 +232,7 @@ func (c *CodecOptionsTester) Marshal(data interface{}, options map[string]interf
 	return c.JsonCodec.Marshal(encapsulated, nil)
 }
 
-func TestAPI_WriteResponseObject_WithCodecOptions(t *testing.T) {
+func TestAPI_WriteResponseObject_CodecOptions(t *testing.T) {
 	http := new(GowebHTTPResponder)
 	codecService := new(codecsservices.WebCodecService)
 	codecService.AddCodec(new(CodecOptionsTester))

--- a/webcontext/web_context.go
+++ b/webcontext/web_context.go
@@ -20,6 +20,7 @@ import (
 type WebContext struct {
 	path               *paths.Path
 	data               objx.Map
+	codecOptions       objx.Map
 	httpRequest        *http.Request
 	httpResponseWriter http.ResponseWriter
 	requestBody        []byte
@@ -61,6 +62,15 @@ func (c *WebContext) Data() objx.Map {
 		c.data = make(objx.Map)
 	}
 	return c.data
+}
+
+// CodecOptions gets a map of options to pass to codecs when
+// responding.
+func (c *WebContext) CodecOptions() objx.Map {
+	if c.codecOptions == nil {
+		c.codecOptions = make(objx.Map)
+	}
+	return c.codecOptions
 }
 
 // FileExtension gets the extension of the file from the HttpRequest().

--- a/webcontext/web_context_test.go
+++ b/webcontext/web_context_test.go
@@ -129,6 +129,16 @@ func TestData(t *testing.T) {
 
 }
 
+func TestCodecOptions(t *testing.T) {
+
+	c := new(WebContext)
+
+	c.codecOptions = nil
+
+	assert.NotNil(t, c.CodecOptions())
+	assert.NotNil(t, c.codecOptions)
+}
+
 func TestPathParams(t *testing.T) {
 
 	responseWriter := new(http_test.TestResponseWriter)


### PR DESCRIPTION
This adds a CodecOptions method to context.Context, which returns the map that is passed as the options value when calling codec.Marshal on the chosen codec in API responders.  This allows custom options to be passed to the chosen codec.
