### PR TITLE
Support X-HTTP-Method-Override to override the current method

### DIFF
--- a/handlers/http_handler.go
+++ b/handlers/http_handler.go
@@ -102,6 +102,11 @@ func (handler *HttpHandler) CodecService() codecsservices.CodecService {
 // ServeHTTP servers the actual HTTP request by buidling a context and running
 // it through all the handlers.
 func (handler *HttpHandler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
+  // override the method if needed
+  method := request.Header.Get("X-HTTP-Method-Override")
+  if method != "" {
+    request.Method = method
+  }
 
 	// make the context
 	ctx := webcontext.NewWebContext(responseWriter, request, handler.codecService)

--- a/handlers/http_handler.go
+++ b/handlers/http_handler.go
@@ -102,11 +102,11 @@ func (handler *HttpHandler) CodecService() codecsservices.CodecService {
 // ServeHTTP servers the actual HTTP request by buidling a context and running
 // it through all the handlers.
 func (handler *HttpHandler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
-  // override the method if needed
-  method := request.Header.Get("X-HTTP-Method-Override")
-  if method != "" {
-    request.Method = method
-  }
+	// override the method if needed
+	method := request.Header.Get("X-HTTP-Method-Override")
+	if method != "" {
+		request.Method = method
+	}
 
 	// make the context
 	ctx := webcontext.NewWebContext(responseWriter, request, handler.codecService)


### PR DESCRIPTION
Not all HTTP libraries support all the HTTP methods, so this allows a header to be set to override the given method.
